### PR TITLE
Fix file extension in output example

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ run_ncbi_blast_all(
    ├── GENE1_blastp_blast.json
 
 📁 blast_results_ncbi/
-   ├── GENE1_ncbi_blast.xml
+   ├── GENE1_ncbi_blast.json
 ```
 
 ## 🧬 FASTA Extraction Logic


### PR DESCRIPTION
## Summary
- correct the NCBI BLAST result filename extension in README

## Testing
- `grep -n ncbi_blast README.md`

------
https://chatgpt.com/codex/tasks/task_e_68526c3a17308328b4359aae62e7de5a