### PR TITLE
Fix __init__ imports

### DIFF
--- a/keggblast/__init__.py
+++ b/keggblast/__init__.py
@@ -1,8 +1,7 @@
-from .utils import *
+from .kegg_utils import *
 from .fasta_tools import *
 from .blast_gget import *
 from .blast_ncbi import *
-from .combined import *
 
 
 


### PR DESCRIPTION
## Summary
- reference `kegg_utils` instead of a missing `utils`
- drop unused import of `combined`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68526c326c648328a8a4254ee3b757ef